### PR TITLE
Fix 50 warnings due to iOS 8 deprecated enumerations

### DIFF
--- a/CalendarDemo/MonthViewController.m
+++ b/CalendarDemo/MonthViewController.m
@@ -30,7 +30,7 @@
 	MGCDateRange *visibleRange = [self.monthPlannerView visibleDays];
 	if (visibleRange)
 	{
-		NSUInteger dayCount = [self.calendar components:NSDayCalendarUnit fromDate:visibleRange.start toDate:visibleRange.end options:0].day;
+		NSUInteger dayCount = [self.calendar components:NSCalendarUnitDay fromDate:visibleRange.start toDate:visibleRange.end options:0].day;
 		NSDateComponents *comp = [NSDateComponents new];
 		comp.day = dayCount / 2;
 		NSDate *centerDate = [self.calendar dateByAddingComponents:comp toDate:visibleRange.start options:0];

--- a/CalendarDemo/WeekViewController.m
+++ b/CalendarDemo/WeekViewController.m
@@ -31,7 +31,7 @@
 
 - (BOOL)dayPlannerView:(MGCDayPlannerView*)view canCreateNewEventOfType:(MGCEventType)type atDate:(NSDate*)date
 {
-	NSDateComponents *comps = [self.calendar components:NSWeekdayCalendarUnit fromDate:date];
+	NSDateComponents *comps = [self.calendar components:NSCalendarUnitWeekday fromDate:date];
 	return comps.weekday != 1;
 }
 
@@ -45,7 +45,7 @@
 
 - (BOOL)dayPlannerView:(MGCDayPlannerView*)view canMoveEventOfType:(MGCEventType)type atIndex:(NSUInteger)index date:(NSDate*)date toType:(MGCEventType)targetType date:(NSDate*)targetDate
 {
-	NSDateComponents *comps = [self.calendar components:NSWeekdayCalendarUnit fromDate:targetDate];
+	NSDateComponents *comps = [self.calendar components:NSCalendarUnitWeekday fromDate:targetDate];
 	return (comps.weekday != 1 && comps.weekday != 7);
 }
 

--- a/CalendarDemo/YearViewController.m
+++ b/CalendarDemo/YearViewController.m
@@ -63,7 +63,7 @@
 {
 	MGCDateRange *visibleRange = [self.yearCalendarView visibleMonthsRange];
 	if (visibleRange) {
-		NSUInteger monthCount = [self.calendar components:NSMonthCalendarUnit fromDate:visibleRange.start toDate:visibleRange.end options:0].month;
+		NSUInteger monthCount = [self.calendar components:NSCalendarUnitMonth fromDate:visibleRange.start toDate:visibleRange.end options:0].month;
 		NSDateComponents *comp = [NSDateComponents new];
 		comp.month = monthCount / 2;
 		NSDate *centerDate = [self.calendar dateByAddingComponents:comp toDate:visibleRange.start options:0];

--- a/CalendarLib/MGCMonthMiniCalendarView.m
+++ b/CalendarLib/MGCMonthMiniCalendarView.m
@@ -113,8 +113,8 @@ static const CGFloat kDefaultHeaderFontSize = 16;
 - (NSUInteger)firstDayColumn
 {
 	NSDate *firstDayInMonth = [self.calendar mgc_startOfMonthForDate:self.date];
-	NSUInteger weekday = [self.calendar components:NSWeekdayCalendarUnit fromDate:firstDayInMonth].weekday;
-	NSUInteger numDaysInWeek = [self.calendar maximumRangeOfUnit:NSWeekdayCalendarUnit].length;
+	NSUInteger weekday = [self.calendar components:NSCalendarUnitWeekday fromDate:firstDayInMonth].weekday;
+	NSUInteger numDaysInWeek = [self.calendar maximumRangeOfUnit:NSCalendarUnitWeekday].length;
 	// zero-based, 0 is the first day of week of current calendar
 	weekday = (weekday + numDaysInWeek - self.calendar.firstWeekday) % numDaysInWeek;
 	return weekday;
@@ -131,9 +131,9 @@ static const CGFloat kDefaultHeaderFontSize = 16;
 	NSUInteger numCols = self.dayLabels.count;
 	NSUInteger numRows = self.showsDayHeader ? 1 : 0;
 	if (yearWise)
-		numRows += [self.calendar maximumRangeOfUnit:NSWeekOfMonthCalendarUnit].length;
+		numRows += [self.calendar maximumRangeOfUnit:NSCalendarUnitWeekOfMonth].length;
 	else
-		numRows += [self.calendar rangeOfUnit:NSWeekCalendarUnit inUnit:NSMonthCalendarUnit forDate:self.date].length;
+		numRows += [self.calendar rangeOfUnit:NSWeekCalendarUnit inUnit:NSCalendarUnitMonth forDate:self.date].length;
 	
 	CGSize viewSize = CGSizeMake(numCols * dayCellSize + (numCols - 1) * space, numRows * dayCellSize + (numRows - 1) * space);
 	
@@ -224,7 +224,7 @@ static const CGFloat kDefaultHeaderFontSize = 16;
 	
 	// draw day cells
 	NSDate *firstDayInMonth = [self.calendar mgc_startOfMonthForDate:self.date];
-	NSUInteger days = [self.calendar rangeOfUnit:NSDayCalendarUnit inUnit:NSMonthCalendarUnit forDate:firstDayInMonth].length;
+	NSUInteger days = [self.calendar rangeOfUnit:NSDayCalendarUnit inUnit:NSCalendarUnitMonth forDate:firstDayInMonth].length;
 	NSUInteger firstCol = [self firstDayColumn];
 	
 	x = rect.origin.x + firstCol * (dayCellSize + space);

--- a/CalendarLib/MGCMonthPlannerEKViewController.m
+++ b/CalendarLib/MGCMonthPlannerEKViewController.m
@@ -255,7 +255,7 @@ static NSString* const EventCellReuseIdentifier = @"EventCellReuseIdentifier";
 {
 	NSArray *events = [self fetchEventsFrom:range.start to:range.end calendars:nil];
 	
-	NSUInteger numDaysInRange = [range components:NSDayCalendarUnit forCalendar:self.calendar].day;
+	NSUInteger numDaysInRange = [range components:NSCalendarUnitDay forCalendar:self.calendar].day;
 	NSMutableDictionary *eventsPerDay = [NSMutableDictionary dictionaryWithCapacity:numDaysInRange];
 	
 	for (EKEvent *ev in events)
@@ -345,7 +345,7 @@ static NSString* const EventCellReuseIdentifier = @"EventCellReuseIdentifier";
 	
 	MGCDateRange *visibleRange = [self visibleMonthsRange];
 	
-	NSUInteger months = [visibleRange components:NSMonthCalendarUnit forCalendar:self.calendar].month;
+	NSUInteger months = [visibleRange components:NSCalendarUnitMonth forCalendar:self.calendar].month;
 	
 	for (int i = 0; i < months; i++)
 	{
@@ -450,7 +450,7 @@ static NSString* const EventCellReuseIdentifier = @"EventCellReuseIdentifier";
 		NSDate *start = [self.calendar mgc_startOfDayForDate:ev.startDate];
 		NSDate *end = [self.calendar mgc_nextStartOfDayForDate:ev.endDate];
 		MGCDateRange *range = [MGCDateRange dateRangeWithStart:start end:end];
-		NSInteger numDays = [range components:NSDayCalendarUnit forCalendar:self.calendar].day;
+		NSInteger numDays = [range components:NSCalendarUnitDay forCalendar:self.calendar].day;
 		
 		evCell.style = (ev.isAllDay || numDays > 1 ? MGCStandardEventViewStylePlain : MGCStandardEventViewStyleDefault|MGCStandardEventViewStyleDot);
 		evCell.style |= ev.isAllDay ?: MGCStandardEventViewStyleDetail;

--- a/CalendarLib/MGCMonthPlannerView.m
+++ b/CalendarLib/MGCMonthPlannerView.m
@@ -263,7 +263,7 @@ typedef enum
 {
 	NSUInteger numMonths = (2 * kMonthsLoadingStep + 1);
 	if (self.dateRange) {
-		NSInteger diff = [self.dateRange components:NSMonthCalendarUnit forCalendar:self.calendar].month;
+		NSInteger diff = [self.dateRange components:NSCalendarUnitMonth forCalendar:self.calendar].month;
 		numMonths = MIN(numMonths, diff);  // cannot load more than the total number of scrollable months
 	}
 	return numMonths;
@@ -334,7 +334,7 @@ typedef enum
 - (NSUInteger)numberOfDaysForMonthAtIndex:(NSUInteger)month
 {
 	NSDate *date = [self dateStartingMonthAtIndex:month];
-	NSRange range = [self.calendar rangeOfUnit:NSDayCalendarUnit inUnit:NSMonthCalendarUnit forDate:date];
+	NSRange range = [self.calendar rangeOfUnit:NSCalendarUnitDay inUnit:NSMonthCalendarUnit forDate:date];
 	return range.length;
 }
 
@@ -342,7 +342,7 @@ typedef enum
 {
 	NSDate *date = [self dateForDayAtIndexPath:indexPath];
 	
-	NSUInteger weekday = [self.calendar components:NSWeekdayCalendarUnit fromDate:date].weekday;
+	NSUInteger weekday = [self.calendar components:NSCalendarUnitWeekday fromDate:date].weekday;
 	// zero-based, 0 is the first day of week of current calendar
 	weekday = (weekday + 7 - self.calendar.firstWeekday) % 7;
 	return weekday;
@@ -423,7 +423,7 @@ typedef enum
 {
 	for (MGCEventsRowView *rowView in [self visibleEventRows])
 	{
-		NSUInteger day = [self.calendar components:NSDayCalendarUnit fromDate:rowView.referenceDate toDate:date options:0].day;
+		NSUInteger day = [self.calendar components:NSCalendarUnitDay fromDate:rowView.referenceDate toDate:date options:0].day;
 		if (NSLocationInRange(day, rowView.daysRange))
 		{
 			return [rowView cellAtIndexPath:[NSIndexPath indexPathForItem:index inSection:day]];
@@ -534,7 +534,7 @@ typedef enum
 		start = self.maxStartDate;
 	}
 	
-	NSUInteger diff = abs((int)[self.calendar components:NSMonthCalendarUnit fromDate:start toDate:date options:0].month);
+	NSUInteger diff = abs((int)[self.calendar components:NSCalendarUnitMonth fromDate:start toDate:date options:0].month);
 	
 	self.startDate = start;
 	return diff;
@@ -743,8 +743,8 @@ typedef enum
 		eventsView = (MGCEventsRowView*)[self.reuseQueue dequeueReusableObjectWithReuseIdentifier:EventsRowViewIdentifier];
 		
 		NSDate *referenceDate = [self.calendar mgc_startOfMonthForDate:rowStart];
-		NSUInteger first = [self.calendar components:NSDayCalendarUnit fromDate:referenceDate toDate:rowStart options:0].day;
-		NSUInteger numDays = [self.calendar rangeOfUnit:NSDayCalendarUnit inUnit:NSWeekOfMonthCalendarUnit forDate:rowStart].length;
+		NSUInteger first = [self.calendar components:NSCalendarUnitDay fromDate:referenceDate toDate:rowStart options:0].day;
+		NSUInteger numDays = [self.calendar rangeOfUnit:NSCalendarUnitDay inUnit:NSCalendarUnitWeekOfMonth forDate:rowStart].length;
 		
 		eventsView.referenceDate = referenceDate;
 		eventsView.scrollEnabled = NO;
@@ -875,7 +875,7 @@ typedef enum
 	
 		NSDate *touchDate = [self dayAtPoint:pt];
 		NSDate *eventDayStart = [self.calendar mgc_startOfDayForDate:self.dragEventDateRange.start];
-		self.dragEventTouchDayOffset = [self.calendar components:NSDayCalendarUnit fromDate:touchDate toDate:eventDayStart options:0].day;
+		self.dragEventTouchDayOffset = [self.calendar components:NSCalendarUnitDay fromDate:touchDate toDate:eventDayStart options:0].day;
 		
 		[self highlightDaysInRange:self.dragEventDateRange];
 
@@ -932,7 +932,7 @@ typedef enum
 		}
 		else
 		{
-			comps.day = [[self daysRangeFromDateRange:self.dragEventDateRange]components:NSDayCalendarUnit forCalendar:self.calendar].day;
+			comps.day = [[self daysRangeFromDateRange:self.dragEventDateRange]components:NSCalendarUnitDay forCalendar:self.calendar].day;
 		}
 		NSDate *highlightEnd = [self.calendar dateByAddingComponents:comps toDate:highlightStart options:0];
 		MGCDateRange *highlight = [MGCDateRange dateRangeWithStart:highlightStart end:highlightEnd];
@@ -1099,7 +1099,7 @@ typedef enum
 		NSDate *date = [self dateStartingMonthAtIndex:indexPath.section];
 		NSUInteger firstColumn = [self columnForDayAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:indexPath.section]];
 		NSUInteger lastColumn = [self columnForDayAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:indexPath.section + 1]];
-		NSUInteger numRows = [self.calendar rangeOfUnit:NSWeekCalendarUnit inUnit:NSMonthCalendarUnit forDate:date].length;
+		NSUInteger numRows = [self.calendar rangeOfUnit:NSWeekCalendarUnit inUnit:NSCalendarUnitMonth forDate:date].length;
 		
 		MGCMonthPlannerBackgroundView *view = [self.eventsView dequeueReusableSupplementaryViewOfKind:MonthBackgroundViewKind withReuseIdentifier:MonthBackgroundViewIdentifier forIndexPath:indexPath];
 		view.numberOfColumns = 7;

--- a/CalendarLib/MGCYearCalendarView.m
+++ b/CalendarLib/MGCYearCalendarView.m
@@ -292,7 +292,7 @@ static const CGFloat kDefaultYearHeaderFontSize = 40;	// deafult font size for t
 		start = self.maxStartDate;
 	}
 	
-	NSUInteger diff = abs((int)[self.calendar components:NSYearCalendarUnit fromDate:start toDate:date options:0].year);
+	NSUInteger diff = abs((int)[self.calendar components:NSCalendarUnitYear fromDate:start toDate:date options:0].year);
 	
 	self.startDate = start;
 	return diff;
@@ -403,7 +403,7 @@ static const CGFloat kDefaultYearHeaderFontSize = 40;	// deafult font size for t
 	NSInteger numSections = 2 * kYearsLoadingStep + 1;
 	if (self.dateRange)
 	{
-		NSInteger diff = [self.calendar components:NSYearCalendarUnit fromDate:self.startDate toDate:self.dateRange.end options:0].year;
+		NSInteger diff = [self.calendar components:NSCalendarUnitYear fromDate:self.startDate toDate:self.dateRange.end options:0].year;
 		if (diff < 3 * kYearsLoadingStep + 1)
 			numSections = diff;
 	}

--- a/CalendarLib/NSCalendar+MGCAdditions.m
+++ b/CalendarLib/NSCalendar+MGCAdditions.m
@@ -36,27 +36,27 @@
 + (NSCalendar*)mgc_calendarFromPreferenceString:(NSString*)string
 {
 	if ([string isEqualToString:@"gregorian"])
-		return [[NSCalendar alloc]initWithCalendarIdentifier:NSGregorianCalendar];
+		return [[NSCalendar alloc]initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
 	else if ([string isEqualToString:@"buddhist"])
-		return [[NSCalendar alloc]initWithCalendarIdentifier:NSBuddhistCalendar];
+		return [[NSCalendar alloc]initWithCalendarIdentifier:NSCalendarIdentifierBuddhist];
 	else if ([string isEqualToString:@"chinese"])
-		return [[NSCalendar alloc]initWithCalendarIdentifier:NSChineseCalendar];
+		return [[NSCalendar alloc]initWithCalendarIdentifier:NSCalendarIdentifierChinese];
 	else if ([string isEqualToString:@"hebrew"])
-		return [[NSCalendar alloc]initWithCalendarIdentifier:NSHebrewCalendar];
+		return [[NSCalendar alloc]initWithCalendarIdentifier:NSCalendarIdentifierHebrew];
 	else if ([string isEqualToString:@"islamic"])
-		return [[NSCalendar alloc]initWithCalendarIdentifier:NSIslamicCalendar];
+		return [[NSCalendar alloc]initWithCalendarIdentifier:NSCalendarIdentifierIslamic];
 	else if ([string isEqualToString:@"islamicCivil"])
-		return [[NSCalendar alloc]initWithCalendarIdentifier:NSIslamicCivilCalendar];
+		return [[NSCalendar alloc]initWithCalendarIdentifier:NSCalendarIdentifierIslamicCivil];
 	else if ([string isEqualToString:@"japanese"])
-		return [[NSCalendar alloc]initWithCalendarIdentifier:NSJapaneseCalendar];
+		return [[NSCalendar alloc]initWithCalendarIdentifier:NSCalendarIdentifierJapanese];
 	else if ([string isEqualToString:@"republicOfChina"])
-		return [[NSCalendar alloc]initWithCalendarIdentifier:NSRepublicOfChinaCalendar];
+		return [[NSCalendar alloc]initWithCalendarIdentifier:NSCalendarIdentifierRepublicOfChina];
 	else if ([string isEqualToString:@"persian"])
-		return [[NSCalendar alloc]initWithCalendarIdentifier:NSPersianCalendar];
+		return [[NSCalendar alloc]initWithCalendarIdentifier:NSCalendarIdentifierPersian];
 	else if ([string isEqualToString:@"indian"])
-		return [[NSCalendar alloc]initWithCalendarIdentifier:NSIndianCalendar];
+		return [[NSCalendar alloc]initWithCalendarIdentifier:NSCalendarIdentifierIndian];
 	else if ([string isEqualToString:@"iso8601"])
-		return [[NSCalendar alloc]initWithCalendarIdentifier:NSISO8601Calendar];
+		return [[NSCalendar alloc]initWithCalendarIdentifier:NSCalendarIdentifierISO8601];
 	return [NSCalendar currentCalendar];
 }
 
@@ -64,7 +64,7 @@
 {
 	if (![self respondsToSelector:@selector(startOfDayForDate:)]) {
 		// keep only day, month and year components
-		NSDateComponents* comps = [self components:NSYearCalendarUnit|NSMonthCalendarUnit|NSDayCalendarUnit fromDate:date];
+		NSDateComponents* comps = [self components:NSCalendarUnitYear|NSCalendarUnitMonth|NSCalendarUnitDay fromDate:date];
 		return [self dateFromComponents:comps];
 	}
 	// startOfDayForDate: is only available in iOS 8 and later


### PR DESCRIPTION
Fixing iOS 8 warnings by replacing old NSCalendarUnit by new ones