### PR TITLE
Initialize startDate for week planner at the beginning of current week

### DIFF
--- a/CalendarLib/MGCDayPlannerView.m
+++ b/CalendarLib/MGCDayPlannerView.m
@@ -437,7 +437,7 @@ static const CGFloat kMaxHourSlotHeight = 150.;
 - (NSDate*)startDate
 {
 	if (_startDate == nil) {
-		_startDate = [self.calendar mgc_startOfDayForDate:[NSDate date]];
+		_startDate = [self.calendar mgc_startOfWeekForDate:[NSDate date]];
 		
 		if (self.dateRange && ![self.dateRange containsDate:_startDate]) {
 			_startDate = self.dateRange.start;


### PR DESCRIPTION
@jumartin 
Not sure if you're okay with this commit,
But on the first launch of week planner you set startDate with the beginning of 'today' day.
But after you move to beginning of current week.