### PR TITLE
Added customizable new timed event duration

### DIFF
--- a/CalendarLib/MGCDayPlannerEKViewController.h
+++ b/CalendarLib/MGCDayPlannerEKViewController.h
@@ -42,6 +42,7 @@
 @property (nonatomic) NSSet *visibleCalendars;
 @property (nonatomic, readonly) EKEventStore *eventStore;
 @property (nonatomic, weak) id<MGCDayPlannerEKViewControllerDelegate> delegate;
+@property (nonatomic) NSTimeInterval durationForNewTimedEvent;
 
 /** designated initializer */
 - (instancetype)initWithEventStore:(EKEventStore*)eventStore;

--- a/CalendarLib/MGCDayPlannerEKViewController.m
+++ b/CalendarLib/MGCDayPlannerEKViewController.m
@@ -69,6 +69,7 @@ static NSString* const EventCellReuseIdentifier = @"EventCellReuseIdentifier";
 {
     if (self = [super initWithNibName:nil bundle:nil]) {
         _eventKitSupport = [[MGCEventKitSupport alloc]initWithEventStore:eventStore];
+        self.durationForNewTimedEvent = 60 * 60;
     }
     return self;
 }
@@ -435,12 +436,22 @@ static NSString* const EventCellReuseIdentifier = @"EventCellReuseIdentifier";
     
     EKEvent *ev = [EKEvent eventWithEventStore:self.eventStore];
     ev.startDate = date;
+    
     NSDateComponents *comps = [NSDateComponents new];
-    comps.hour = 1;
+    comps.day = ((NSInteger) self.durationForNewTimedEvent) / (60 * 60 * 24);
+    comps.hour = (((NSInteger) self.durationForNewTimedEvent) / (60 * 60)) - (comps.day * 24);
+    comps.minute = (((NSInteger) self.durationForNewTimedEvent) / 60) - (comps.day * 24 * 60) - (comps.hour * 60);
+    comps.second = ((NSInteger) round(self.durationForNewTimedEvent)) % 60;
+
     ev.endDate = [self.calendar dateByAddingComponents:comps toDate:date options:0];
     ev.allDay = (type == MGCAllDayEventType) ? YES : NO;
     
     [self showPopoverForNewEvent:ev];
+}
+
+- (NSTimeInterval)dayPlannerView:(MGCDayPlannerView *)view durationForNewTimedEventTypeAtDate:(NSDate *)date
+{
+    return self.durationForNewTimedEvent;
 }
 
 #pragma mark - MGCDayPlannerViewDelegate

--- a/CalendarLib/MGCDayPlannerView.h
+++ b/CalendarLib/MGCDayPlannerView.h
@@ -525,6 +525,12 @@ typedef NS_ENUM(NSUInteger, MGCDayPlannerTimeMark) {
 - (MGCEventView*)dayPlannerView:(MGCDayPlannerView*)view viewForNewEventOfType:(MGCEventType)type atDate:(NSDate*)date;
 
 /*!
+	@abstract	Asks the data source for the duration for a new MGCTimedEventType
+	@discussion	If this method is not implemented by the data source, a standard duration will be used
+ */
+- (NSTimeInterval)dayPlannerView:(MGCDayPlannerView*)view durationForNewTimedEventTypeAtDate:(NSDate*)date;
+
+/*!
 	@abstract	Asks the data source if an event can be created with given type and date. 
 	@discussion	This method is not called if day planner view's canCreateEvents property is set to NO.
  */

--- a/CalendarLib/MGCDayPlannerView.m
+++ b/CalendarLib/MGCDayPlannerView.m
@@ -1133,7 +1133,7 @@ static const CGFloat kMaxHourSlotHeight = 150.;
 	if (type == MGCTimedEventType) {
 		NSDateComponents *comp = [self.calendar components:NSCalendarUnitHour|NSCalendarUnitMinute fromDate:date];
         CGFloat y =  [self offsetFromTime:(comp.hour*3600. + comp.minute*60.) rounding:0];
- 		CGRect rect = CGRectMake(x, y, self.dayColumnSize.width, self.hourSlotHeight);
+ 		CGRect rect = CGRectMake(x, y, self.dayColumnSize.width, self.interactiveCellTimedEventHeight);
 		return [self convertRect:rect fromView:self.timedEventsView];
 	}
 	else if (type == MGCAllDayEventType) {
@@ -1251,8 +1251,14 @@ static const CGFloat kMaxHourSlotHeight = 150.;
 		}
 	}
 	
-	CGRect rect = [self rectForNewEventOfType:type atDate:date];
-	self.interactiveCellTimedEventHeight =  self.hourSlotHeight;
+    if ([self.dataSource respondsToSelector:@selector(dayPlannerView:durationForNewTimedEventTypeAtDate:)]) {
+        NSTimeInterval durationInSeconds = [self.dataSource dayPlannerView:self durationForNewTimedEventTypeAtDate:date];
+        self.interactiveCellTimedEventHeight = floor(durationInSeconds * self.hourSlotHeight / 60.0f / 60.0f);  
+    }
+    else {
+        self.interactiveCellTimedEventHeight =  self.hourSlotHeight;
+    }
+    CGRect rect = [self rectForNewEventOfType:type atDate:date];
 	self.interactiveCell.frame = rect;
 	[self addSubview:self.interactiveCell];
 	self.interactiveCell.hidden = NO;


### PR DESCRIPTION
Previously a new event was hardcoded to be 1 hour. Now the datasource
can specify the duration of new events. Included a convenience property
for setting it on the MGCDayPlannerEKViewController.