### PR TITLE
New property dayHeaderTextColor in MGCDayPlannerView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v. 2.0.1
+- `MGCDayPlannerView` :
+    - new property `dayHeaderTextColor`
+
 ## v. 2.0
 
 - Deployment target is now iOS 8.0

--- a/CalendarLib.podspec
+++ b/CalendarLib.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 	s.name         = "CalendarLib"
-	s.version      = "2.0"
+	s.version      = "2.0.1"
 	s.summary      = "A set of views and controllers for displaying and scheduling events on iOS"
 	s.homepage     = "https://github.com/jumartin/Calendar"
 	s.license      = "MIT"

--- a/CalendarLib.podspec
+++ b/CalendarLib.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
 	s.license      = "MIT"
 	s.author       = { "Julien Martin" => "julienmartin@hotmail.com" }
 	s.platform     = :ios, "8.0"
-	s.source       = { :git => "https://github.com/jumartin/Calendar.git", :tag => s.version.to_s }
+	s.source       = { :git => "https://github.com/ATINO-GmbH/Calendar.git", :tag => s.version.to_s }
 	s.screenshots 	= [ "https://raw.githubusercontent.com/jumartin/Calendar/master/CalendarDocs/DayPlannerView.jpg", "https://raw.githubusercontent.com/jumartin/Calendar/master/CalendarDocs/MonthPlannerView.jpg", "https://raw.githubusercontent.com/jumartin/Calendar/master/CalendarDocs/YearView.jpg"]
     s.source_files  = "CalendarLib/**/*.{h,m}"
     s.public_header_files = "CalendarLib/{MGCDateRange.h,NSCalendar+MGCAdditions.h,NSAttributedString+MGCAdditions.h,MGCDayPlannerEKViewController.h,MGCMonthPlannerEKViewController.h,MGCEventView.h,MGCStandardEventView.h,MGCDayPlannerView.h,MGCDayPlannerViewController.h,MGCMonthPlannerView.h,MGCMonthPlannerViewController.h,MGCMonthMiniCalendarView.h,MGCYearCalendarView.h,MGCReusableObjectQueue.h}"

--- a/CalendarLib/MGCDayPlannerView.h
+++ b/CalendarLib/MGCDayPlannerView.h
@@ -117,6 +117,13 @@ typedef NS_ENUM(NSUInteger, MGCDayPlannerTimeMark) {
 */
 @property (nonatomic) CGFloat dayHeaderHeight;
 
+
+/*
+	@abstract	Returns the color of text of the top row showing days.
+	@discussion The default value is white.
+ */
+@property (nonatomic) UIColor *dayHeaderTextColor;
+
 /*!
 	@abstract	Returns the color of the vertical separator lines between days.
 	@discussion The default value is light gray.

--- a/CalendarLib/MGCDayPlannerView.m
+++ b/CalendarLib/MGCDayPlannerView.m
@@ -1841,7 +1841,13 @@ static const CGFloat kMaxHourSlotHeight = 150.;
         if ([self.calendar mgc_isDate:date sameDayAsDate:[NSDate date]]) {
             accessoryTypes |= MGCDayColumnCellAccessoryMark;
             dayCell.markColor = self.tintColor;
-            color = [UIColor whiteColor];
+            
+            if(self.dayHeaderTextColor){
+                color = self.dayHeaderTextColor;
+            }else{
+                color = [UIColor whiteColor];
+            }
+            
             font = [UIFont boldSystemFontOfSize:14];
         }
         


### PR DESCRIPTION
We wanted to change the color of the text in the header view of the day planner.
So we added the property dayHeaderTextColor to your MGCDayPlannerView.

Please be aware that we also modified the podspec since we need to use a private podspec repo.
