### PR TITLE
Allow selection of time events which are not completely in view

### DIFF
--- a/CalendarLib/MGCDayPlannerView.m
+++ b/CalendarLib/MGCDayPlannerView.m
@@ -1696,7 +1696,7 @@ static const CGFloat kMaxHourSlotHeight = 150.;
         frame.origin = [self offsetFromDate:self.interactiveCellDate eventType:self.interactiveCellType];
         frame.size.width = self.dayColumnSize.width;
 		self.interactiveCell.frame = frame;
-        self.interactiveCell.hidden = (self.interactiveCellType == MGCTimedEventType && !CGRectContainsRect(self.timedEventsView.frame, frame));
+        self.interactiveCell.hidden = (self.interactiveCellType == MGCTimedEventType && !CGRectIntersectsRect(self.timedEventsView.frame, frame));
 	}
 	
 	[self.allDayEventsView flashScrollIndicators];


### PR DESCRIPTION
Noticed the problem that when moving events which were slightly out of
view (e.g. long duration events or at high zoom levels), the
interactive view wasn’t showing. Using intersection of the two
rectangles rather than requiring full containment covers these cases as
well.