### PR TITLE
Complex layouting for day view

### DIFF
--- a/Calendar.xcodeproj/project.pbxproj
+++ b/Calendar.xcodeproj/project.pbxproj
@@ -505,7 +505,7 @@
 				ORGANIZATIONNAME = "Julien Martin";
 				TargetAttributes = {
 					72B5D8ED180D73E0004ADB86 = {
-						DevelopmentTeam = RSMX8QUE69;
+						DevelopmentTeam = 9L2H2A796T;
 					};
 				};
 			};
@@ -757,6 +757,7 @@
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEVELOPMENT_TEAM = 9L2H2A796T;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "CalendarDemo/Calendar-Prefix.pch";
 				INFOPLIST_FILE = "$(SRCROOT)/CalendarDemo/Calendar-Info.plist";
@@ -777,6 +778,7 @@
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEVELOPMENT_TEAM = 9L2H2A796T;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "CalendarDemo/Calendar-Prefix.pch";
 				INFOPLIST_FILE = "$(SRCROOT)/CalendarDemo/Calendar-Info.plist";

--- a/CalendarDemo/CustomTimedEventsViewLayout.h
+++ b/CalendarDemo/CustomTimedEventsViewLayout.h
@@ -1,0 +1,13 @@
+//
+//  CustomTimedEventsViewLayout.h
+//  Calendar
+//
+//  Created by GK on 2016.11.29..
+//  Copyright © 2016. Julien Martin. All rights reserved.
+//
+
+#import "MGCTimedEventsViewLayout.h"
+
+@interface CustomTimedEventsViewLayout : MGCTimedEventsViewLayout
+
+@end

--- a/CalendarDemo/CustomTimedEventsViewLayout.m
+++ b/CalendarDemo/CustomTimedEventsViewLayout.m
@@ -1,0 +1,13 @@
+//
+//  CustomTimedEventsViewLayout.m
+//  Calendar
+//
+//  Created by GK on 2016.11.29..
+//  Copyright © 2016. Julien Martin. All rights reserved.
+//
+
+#import "CustomTimedEventsViewLayout.h"
+
+@implementation CustomTimedEventsViewLayout
+
+@end

--- a/CalendarDemo/MainViewController.m
+++ b/CalendarDemo/MainViewController.m
@@ -143,6 +143,7 @@ typedef enum : NSUInteger
         _dayViewController.calendar = self.calendar;
         _dayViewController.showsWeekHeaderView = YES;
         _dayViewController.delegate = self;
+        _dayViewController.dayPlannerView.eventCoveringType = MGCDayPlannerCoveringTypeComplex;
     }
     return _dayViewController;
 }

--- a/CalendarLib/MGCDayPlannerView.h
+++ b/CalendarLib/MGCDayPlannerView.h
@@ -57,6 +57,12 @@ typedef NS_ENUM(NSUInteger, MGCDayPlannerTimeMark) {
 };
 
 
+typedef NS_ENUM(NSUInteger, MGCDayPlannerCoveringType) {
+    MGCDayPlannerCoveringTypeClassic = 0,
+    MGCDayPlannerCoveringTypeComplex = 1
+};
+
+
 /*!
  * You can use an instance of MGCDayPlannerView to display events as a schedule.
  *
@@ -232,6 +238,13 @@ typedef NS_ENUM(NSUInteger, MGCDayPlannerTimeMark) {
  */
 @property (nonatomic, weak) id<MGCDayPlannerViewDataSource> dataSource;
 
+/*!
+    @abstract   How to handle multiple overlapping events at displaying.
+    @discussion `MGCDayPlannerCoveringTypeClassic` is recommended for 2-3 covering events.
+                `MGCDayPlannerCoveringTypeComplex` is recommended for more. The first one tries to maximize the event box sizes. The latter one maximizes the disjunct space by splitting days into columns as neccessary.
+    @discussion Default value is `MGCDayPlannerCoveringTypeClassic`.
+ */
+@property (nonatomic) MGCDayPlannerCoveringType eventCoveringType;
 
 /*!
 	@group Navigating through a day planner view

--- a/CalendarLib/MGCDayPlannerView.m
+++ b/CalendarLib/MGCDayPlannerView.m
@@ -192,6 +192,7 @@ static const CGFloat kMaxHourSlotHeight = 150.;
 	_canCreateEvents = YES;
 	_canMoveEvents = YES;
 	_allowsSelection = YES;
+    _eventCoveringType = TimedEventCoveringTypeClassic;
 	
 	_reuseQueue = [[MGCReusableObjectQueue alloc] init];
 	_loadingDays = [NSMutableOrderedSet orderedSetWithCapacity:14];
@@ -469,6 +470,13 @@ static const CGFloat kMaxHourSlotHeight = 150.;
     for (UIView *v in [self.timedEventsView visibleSupplementaryViewsOfKind:DimmingViewKind]) {
         v.backgroundColor = dimmingColor;
     }
+}
+
+// public
+- (void)setEventCoveringType:(MGCDayPlannerCoveringType)eventCoveringType {
+    _eventCoveringType = eventCoveringType;
+    self.timedEventsViewLayout.coveringType = eventCoveringType == MGCDayPlannerCoveringTypeComplex ? TimedEventCoveringTypeComplex : TimedEventCoveringTypeClassic;
+    [self.dayColumnsView setNeedsDisplay];
 }
 
 #pragma mark - Private properties
@@ -966,6 +974,7 @@ static const CGFloat kMaxHourSlotHeight = 150.;
 		_timedEventsViewLayout = [MGCTimedEventsViewLayout new];
 		_timedEventsViewLayout.delegate = self;
 		_timedEventsViewLayout.dayColumnSize = self.dayColumnSize;
+        _timedEventsViewLayout.coveringType = self.eventCoveringType == TimedEventCoveringTypeComplex ? TimedEventCoveringTypeComplex : TimedEventCoveringTypeClassic;
 	}
 	return _timedEventsViewLayout;
 }

--- a/CalendarLib/MGCEventCellLayoutAttributes.h
+++ b/CalendarLib/MGCEventCellLayoutAttributes.h
@@ -34,5 +34,6 @@
 @interface MGCEventCellLayoutAttributes : UICollectionViewLayoutAttributes
 
 @property (nonatomic) CGFloat visibleHeight;  // height of the visible portion of the cell
+@property (nonatomic) NSUInteger numberOfOtherCoveredAttributes;    // number of events which share a time section with this attribute
 
 @end

--- a/CalendarLib/MGCTimedEventsViewLayout.h
+++ b/CalendarLib/MGCTimedEventsViewLayout.h
@@ -53,21 +53,6 @@ typedef enum : NSUInteger
 @end
 
 
-// Helper cluster objects for `TimedEventCoveringTypeComplex` layout calculations
-@interface MGCEventCellLayoutAttributesCluster : NSObject
-
-@property (nonatomic, strong) NSMutableArray<MGCEventCellLayoutAttributes *> *contents; // attributes sorted by time
-@property (nonatomic) NSUInteger columnSize;    // the maxmimum number of attributes which have covering points at the same time
-
-
-/**
- Refresh the `columnSize` property's value
- */
-- (void)calculateColumnSize;
-
-@end
-
-
 // This collection view layout is responsible for the layout of event views in the timed-events part
 // of the day planner view.
 @interface MGCTimedEventsViewLayout : UICollectionViewLayout

--- a/CalendarLib/MGCTimedEventsViewLayout.h
+++ b/CalendarLib/MGCTimedEventsViewLayout.h
@@ -32,6 +32,12 @@
 
 static NSString* const DimmingViewKind = @"DimmingViewKind";
 
+typedef enum : NSUInteger
+{
+    TimedEventCoveringTypeClassic = 0,
+    TimedEventCoveringTypeComplex  = 1 << 0,
+} TimedEventCoveringType;
+
 
 @protocol MGCTimedEventsViewLayoutDelegate;
 
@@ -54,6 +60,7 @@ static NSString* const DimmingViewKind = @"DimmingViewKind";
 @property (nonatomic) CGSize dayColumnSize;
 @property (nonatomic) CGFloat minimumVisibleHeight;  // if 2 cells overlap, and the height of the uncovered part of the upper cell is less than this value, the column is split
 @property (nonatomic) BOOL ignoreNextInvalidation;  // for some reason, UICollectionView reloadSections: messes up with scrolling and animations so we have to stick with using reloadData even when only individual sections need to be invalidated. As a workaroud, we explicitly invalidate them with custom context, and set this flag to YES before calling reloadData
+@property (nonatomic) TimedEventCoveringType coveringType;  // how to handle event covering
 
 @end
 

--- a/CalendarLib/MGCTimedEventsViewLayout.h
+++ b/CalendarLib/MGCTimedEventsViewLayout.h
@@ -40,6 +40,7 @@ typedef enum : NSUInteger
 
 
 @protocol MGCTimedEventsViewLayoutDelegate;
+@class MGCEventCellLayoutAttributes;
 
 
 // Custom invalidation context for MGCTimedEventsViewLayout
@@ -48,6 +49,21 @@ typedef enum : NSUInteger
 @property (nonatomic) BOOL invalidateDimmingViews;  // set to true if layout attributes of dimming views must be recomputed
 @property (nonatomic) BOOL invalidateEventCells;  // set to true if layout attributes of event cells must be recomputed
 @property (nonatomic) NSMutableIndexSet *invalidatedSections;   // sections whose layout attributes (dimming views or event cells) must be recomputed - if nil, recompute everything
+
+@end
+
+
+// Helper cluster objects for `TimedEventCoveringTypeComplex` layout calculations
+@interface MGCEventCellLayoutAttributesCluster : NSObject
+
+@property (nonatomic, strong) NSMutableArray<MGCEventCellLayoutAttributes *> *contents; // attributes sorted by time
+@property (nonatomic) NSUInteger columnSize;    // the maxmimum number of attributes which have covering points at the same time
+
+
+/**
+ Refresh the `columnSize` property's value
+ */
+- (void)calculateColumnSize;
 
 @end
 

--- a/CalendarLib/MGCTimedEventsViewLayout.m
+++ b/CalendarLib/MGCTimedEventsViewLayout.m
@@ -297,6 +297,8 @@ static NSString* const EventCellsKey = @"EventCellsKey";
 
 - (void)expandCellsToMaxWidthInCluster:(NSMutableArray<MGCEventCellLayoutAttributes *> *)cluster
 {
+    const NSUInteger padding = 2.f;
+    
     // Expand the attributes to maximum possible width
     NSMutableArray<NSMutableArray<MGCEventCellLayoutAttributes *> *> *columns = [NSMutableArray new];
     [columns addObject:[NSMutableArray new]];
@@ -324,15 +326,19 @@ static NSString* const EventCellsKey = @"EventCellsKey";
     for (NSMutableArray<MGCEventCellLayoutAttributes *> *column in columns) {
         maxRowCount = fmax(maxRowCount, column.count);
     }
+    
+    CGFloat totalWidth = self.dayColumnSize.width - 2.f;
+
     for (NSInteger i = 0; i < maxRowCount; i++) {
         // Set the x position of the rect
         NSInteger j = 0;
         for (NSMutableArray<MGCEventCellLayoutAttributes *> *column in columns) {
+            CGFloat colWidth = totalWidth / columns.count;
             if (column.count >= i + 1) {
                 MGCEventCellLayoutAttributes *attribs = [column objectAtIndex:i];
-                attribs.frame = MGCAlignedRectMake(attribs.frame.origin.x + j * attribs.frame.size.width / columns.count,
+                attribs.frame = MGCAlignedRectMake(attribs.frame.origin.x + j * colWidth,
                                                    attribs.frame.origin.y,
-                                                   attribs.frame.size.width / columns.count,
+                                                   colWidth,
                                                    attribs.frame.size.height);
             }
             j++;


### PR DESCRIPTION
Fixes #42: Added `eventCoveringType` to `MGCDayPlannerView`. You can switch between classic and complex layouts. Complex tries to fill the available space in the day planner view horizontally with the events without having them overlap each other.